### PR TITLE
Needed so that the correct debian package version is created

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libnice (0.1.13.1~0) unstable; urgency=medium
+
+  * Update to release 0.1.13.1
+
+ -- David R Robison <kc7bfi.dr@gmail.com>  Thu, 11 Feb 2016 16:00:00 -0500
+
 libnice (0.1.7.1) unstable; urgency=medium
 
   [ Simon McVittie ]


### PR DESCRIPTION
This was required so that the correct Debian package version was used so that it would satisfy the required libnice version needed by other kms projects.