### PR TITLE
Update dependency on "libgupnp-igd-1.0-dev" to actually required version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,9 +15,8 @@ Build-Depends: autotools-dev,
                libgstreamer-plugins-base0.10-dev,
                libgstreamer1.0-dev,
                libgstreamer1.5-dev,
-               libgupnp-igd-1.0-dev (>= 0.1.2),
-               gtk-doc-tools,
-               libgupnp-igd-1.0-dev
+               libgupnp-igd-1.0-dev (>= 0.2.4),
+               gtk-doc-tools
 Standards-Version: 3.9.5
 Homepage: http://nice.freedesktop.org/
 Vcs-Git: git://anonscm.debian.org/pkg-telepathy/libnice.git


### PR DESCRIPTION
In https://github.com/Kurento/libnice/blob/eebfdabef909410da3054f6f2a888f8c9909f9b2/configure.ac#L290 the version is checked to be `0.2.4` or newer, so that should also be the build dependency.