### PR TITLE
Libnice Crash  Fix (https://github.com/Kurento/bugtracker/issues/247 )

### DIFF
--- a/agent/component.c
+++ b/agent/component.c
@@ -124,6 +124,7 @@ socket_source_attach (SocketSource *socket_source, GMainContext *context)
 static void
 socket_source_detach (SocketSource *source)
 {
+
   nice_debug ("Detaching source %p (socket %p, FD %d) from context %p",
       source->source, source->socket,
       (source->socket->fileno != NULL) ?
@@ -625,7 +626,6 @@ nice_component_detach_socket (NiceComponent *component, NiceSocket *nicesock)
   component->socket_sources = g_slist_delete_link (component->socket_sources, l);
   component->socket_sources_age++;
 
-  socket_source_detach (socket_source);
   socket_source_free (socket_source);
 }
 

--- a/socket/socket.c
+++ b/socket/socket.c
@@ -277,6 +277,7 @@ void
 nice_socket_free (NiceSocket *sock)
 {
   if (sock) {
+    socket_remove_from_hash(sock);
     sock->close (sock);
     g_slice_free (NiceSocket,sock);
   }

--- a/socket/socket.h
+++ b/socket/socket.h
@@ -73,8 +73,10 @@ typedef void (*NiceSocketWritableCb) (NiceSocket *sock, gpointer user_data);
 struct _NiceSocket
 {
   NiceAddress addr;
+  NiceAddress* key;
   NiceSocketType type;
   GSocket *fileno;
+  NiceSocket* server_sock;
   /* Implementations must handle any value of n_recv_messages, including 0. Iff
    * n_recv_messages is 0, recv_messages may be NULL. */
   gint (*recv_messages) (NiceSocket *sock,

--- a/socket/tcp-passive.c
+++ b/socket/tcp-passive.c
@@ -176,6 +176,7 @@ nice_tcp_passive_socket_new (GMainContext *ctx, NiceAddress *addr)
   return sock;
 }
 
+
 static void
 socket_close (NiceSocket *sock)
 {
@@ -309,13 +310,25 @@ nice_tcp_passive_socket_accept (NiceSocket *sock)
 
   if (new_socket) {
     NiceAddress *key = nice_address_dup (&remote_addr);
-
+     new_socket->key = key;
+     new_socket->server_sock = sock;
     nice_socket_set_writable_callback (new_socket, _child_writable_cb, sock);
     g_hash_table_insert (priv->connections, key, new_socket);
   }
   return new_socket;
 }
 
+void socket_remove_from_hash(NiceSocket* sock)
+{
+  TcpPassivePriv* server_priv;
+  if((sock->server_sock != NULL))
+  {
+   server_priv = sock->server_sock->priv;
+   if(server_priv)
+   g_hash_table_remove(server_priv->connections,sock->key);
+  }
+
+}
 static guint nice_address_hash (const NiceAddress * key)
 {
   gchar ip[INET6_ADDRSTRLEN];

--- a/socket/tcp-passive.h
+++ b/socket/tcp-passive.h
@@ -45,7 +45,7 @@ G_BEGIN_DECLS
 
 NiceSocket * nice_tcp_passive_socket_new (GMainContext *ctx, NiceAddress *addr);
 NiceSocket * nice_tcp_passive_socket_accept (NiceSocket *socket);
-
+void socket_remove_from_hash(NiceSocket* sock);
 
 G_END_DECLS
 


### PR DESCRIPTION
Hi , 
Sub: Kurento - Libnice Crash  Fix (libnice crashes in socket code: g_socket_send_message (socket=0x0))
Ref: https://github.com/Kurento/bugtracker/issues/247 
During analysis we found that issue was there while sending a data on deleted passive socket.
while back-tracing this we found that passive socket got deleted in a scenario (component_update_selected_pair in our case), but we did not remove its entry from hash table of its peer socket (server socket). Now later when we are about to send data in socket_send_messages function we try to get hold of peer socket from hash table of active socket as below

```
TcpPassivePriv *priv = sock->priv;

if (to) {
NiceSocket *peer_socket = g_hash_table_lookup (priv->connections, to);
if (peer_socket)
return nice_socket_send_messages (peer_socket, to, messages, n_messages);
}
return -1
```

Here lookup would return success but the contents of this peer_socket memory address would be junk values as we have already deleted the same because of reason specified above.

this entry we added during creation of new socket in nice_tcp_passive_socket_accept function
```
if (new_socket) {
NiceAddress *key = nice_address_dup (&remote_addr);

nice_socket_set_writable_callback (new_socket, _child_writable_cb, sock);
g_hash_table_insert (priv->connections, key, new_socket);
}
```
In fact we have never removed the entry from hash table even if socket got deleted for any reason.
Now in order to fix this, i have added a function to remove the entry from hash table whenever we delete a socket. this function is getting called from nice_socket_free.

After this fix i have tried multiple iterations of my load/stress test script(i.e. multiple user Frequent join/leave scenarios) and it is working fine without any issues now.

Please review the patch available at branch -  ( fork from libnice tag 0.1.14) 
https://github.com/puneet89/libnice/tree/patch_gsocket_fix1

Thanks
Puneet Singh